### PR TITLE
Add typing to gpapi module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stack-pack-gpapi",
   "description": "A GP stack package that provides secure access to the main GP API",
-  "version": "2.4.2",
+  "version": "3.0.0",
   "author": "GoodPractice",
   "license": "UNLICENSED",
   "homepage": "https://github.com/gp-technical/stack-pack-gpapi",
@@ -10,6 +10,7 @@
     "url": "https://github.com/gp-technical/stack-pack-gpapi"
   },
   "main": "build/index.js",
+  "types": "build/types/index.d.ts",
   "scripts": {
     "build:debug": "yarn lint && sp-build-debug",
     "lint": "eslint --ext .js,.jsx .",

--- a/src/gpapi.js
+++ b/src/gpapi.js
@@ -112,7 +112,7 @@ const setApplicationToken = async ({ app, apiUrl, keyPublic, keyPrivate }) => {
   return app.get('application-token')
 }
 
-const setUserToken = async ({ app, apiUrl, keyAdmin }) => {
+const setUserToken = async ({ app, apiUrl }) => {
   var url = `${apiUrl}/security/login/application/gpapi`
   const payload = { ApplicationToken: app.get('application-token') }
   const { token } = await request.post(url, payload)
@@ -146,7 +146,7 @@ const check = async () => {
 
 var apiGetProfileFromToken
 const attachGetProfileFromToken = async ({ apiUrl }) => {
-  apiGetProfileFromToken = async (app, userToken) => {
+  apiGetProfileFromToken = async userToken => {
     const user = await request.get(`${apiUrl}/security/login/user/token/${userToken}`)
     const profile = {
       nameId: user.Id,
@@ -164,8 +164,8 @@ const attachGetProfileFromToken = async ({ apiUrl }) => {
   }
 }
 
-const getProfileFromToken = async (app, userToken) => {
-  return apiGetProfileFromToken(app, userToken)
+const getProfileFromToken = async userToken => {
+  return apiGetProfileFromToken(userToken)
 }
 
 const requiresHandshake = () => {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -50,8 +50,8 @@ declare module 'stack-pack-gpapi' {
 
   export function handshake(handshakeOpts:HandshakeOpts) : Promise<null>;
   export function requiresHandshake(): boolean;
-  export function get(url:string, queryParams?:QueryParams) : Promise<any>;
-  export function post(url:string, payload?:Payload, queryParams?: QueryParams) : Promise<any>;
+  export function get<T>(url:string, queryParams?:QueryParams) : Promise<T>;
+  export function post<T>(url:string, payload?:Payload, queryParams?: QueryParams) : Promise<T>;
   export function check() : Promise<CheckResult>;
   export function getProfileFromToken(userToken:string) : Promise<UserProfile>
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,58 @@
+declare module 'stack-pack-gpapi' {
+  export interface HandshakeOpts {
+    /**
+     * Could be any web app framework, normally you would use an express app here
+     */
+    app:any
+    /**
+     * GP api URL
+     */
+    apiUrl:string
+    /**
+     * GP public key to enable connection with the api
+     */
+    keyPublic:string
+    /**
+     * GP private key to enable connection with the api
+     */
+    keyPrivate:string
+  }
+
+  export interface QueryParams {
+    /**
+     * Object to represent a "list" of query params
+     */
+    [key:string]: string|number|boolean
+  }
+
+  export interface Payload {
+    /**
+     * Values for a post payload
+     */
+    [key:string]: any
+  }
+
+  export interface CheckResult {
+    url:string,
+    ping:string,
+    db:string
+  }
+
+  export interface UserProfile {
+    nameId: string,
+    firstname: string,
+    lastname: string,
+    email: string,
+    token: string
+    client?: { id: string, name: string },
+    subscription?: { id: string, name: string }
+  }
+
+  export function handshake(handshakeOpts:HandshakeOpts) : Promise<null>;
+  export function requiresHandshake(): boolean;
+  export function get(url:string, queryParams?:QueryParams) : Promise<any>;
+  export function post(url:string, payload?:Payload, queryParams?: QueryParams) : Promise<any>;
+  export function check() : Promise<CheckResult>;
+  export function getProfileFromToken(userToken:string) : Promise<UserProfile>
+
+}


### PR DESCRIPTION
Note: this introduces a breaking change for the function `getProfileFromToken`. Now it receives only 1 argument, instead of two (one of them was unused)